### PR TITLE
Fix typo that breaks build

### DIFF
--- a/src/mesh_builder.rs
+++ b/src/mesh_builder.rs
@@ -54,7 +54,6 @@ impl LyonMeshBuilder
     /// Uses [`TriangleStrip`](PrimitiveTopology::TriangleStrip) as the default primitive topology.
     pub fn build(self) -> Mesh
     {
-        LyonMeshBuilder::
         self.build_with_topology(PrimitiveTopology::TriangleStrip)
     }
 


### PR DESCRIPTION
In `LyonMeshBuilder::build` there is a typo (probably a remains of old code) that prevents the crate to build without errors. This pull request fixes that.