### PR TITLE
Update to work with Bevy 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ description = "A simple library to provide access to lyon-powered meshes in bevy
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.1.3"
+bevy = "0.2.1"
 lyon = "0.16.0"
 smart-default = "0.6.0"

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -1,12 +1,6 @@
-use bevy::{
-    prelude::*,
-};
+use bevy::prelude::*;
 
-use bevy_lyon::{
-    shapes,
-    LyonMeshBuilder,
-    math
-};
+use bevy_lyon::{math, shapes, LyonMeshBuilder};
 
 fn main() {
     App::build()
@@ -24,68 +18,59 @@ fn setup_system(
     let green = materials.add(Color::GREEN.into());
     let blue = materials.add(Color::BLUE.into());
 
-    let fill_circle = meshes.add(LyonMeshBuilder::with_only(
-        shapes::FillCircle {
-            center: math::point(-100.0, 0.0),
-            ..Default::default()
-        }
-    ));
+    let fill_circle = meshes.add(LyonMeshBuilder::with_only(shapes::FillCircle {
+        center: math::point(-100.0, 0.0),
+        ..Default::default()
+    }));
 
-    let stroke_circle = meshes.add(LyonMeshBuilder::with_only(
-        shapes::StrokeCircle {
-            center: math::point(-100.0, 0.0),
-            radius: 35.0,
-            ..Default::default()
-        }
-    ));
+    let stroke_circle = meshes.add(LyonMeshBuilder::with_only(shapes::StrokeCircle {
+        center: math::point(-100.0, 0.0),
+        radius: 35.0,
+        ..Default::default()
+    }));
 
-    let ellipse = meshes.add(LyonMeshBuilder::with_only(
-        shapes::StrokeEllipse {
-            center: math::point(50.0, 25.0),
-            ..Default::default()
-        }
-    ));
+    let ellipse = meshes.add(LyonMeshBuilder::with_only(shapes::StrokeEllipse {
+        center: math::point(50.0, 25.0),
+        ..Default::default()
+    }));
 
-    let convex_polyline = meshes.add(LyonMeshBuilder::with_only(
-        shapes::FillConvexPolyline {
-            points: vec![
-                math::point(0.0, 0.0),
-                math::point(25.0, 50.0),
-                math::point(50.0, 0.0),
-                math::point(50.0, -100.0),
-                math::point(25.0, -150.0),
-                math::point(0.0, -100.0)
-            ],
-            ..Default::default()
-        }
-    ));
+    let convex_polyline = meshes.add(LyonMeshBuilder::with_only(shapes::FillConvexPolyline {
+        points: vec![
+            math::point(0.0, 0.0),
+            math::point(25.0, 50.0),
+            math::point(50.0, 0.0),
+            math::point(50.0, -100.0),
+            math::point(25.0, -150.0),
+            math::point(0.0, -100.0),
+        ],
+        ..Default::default()
+    }));
 
     commands
         .spawn(Camera2dComponents::default())
         .spawn(SpriteComponents {
             mesh: fill_circle,
             material: red,
-            sprite: Sprite { size: Vec2::new(1.0, 1.0) },
+            sprite: Sprite::new(Vec2::new(1.0, 1.0)),
             ..Default::default()
         })
         .spawn(SpriteComponents {
             mesh: stroke_circle,
             material: green,
-            sprite: Sprite { size: Vec2::new(1.0, 1.0) },
+            sprite: Sprite::new(Vec2::new(1.0, 1.0)),
             ..Default::default()
         })
         .spawn(SpriteComponents {
             mesh: ellipse,
             material: red,
-            sprite: Sprite { size: Vec2::new(1.0, 1.0) },
+            sprite: Sprite::new(Vec2::new(1.0, 1.0)),
             ..Default::default()
         })
         .spawn(SpriteComponents {
             mesh: convex_polyline,
             material: blue,
-            sprite: Sprite { size: Vec2::new(1.0, 1.0) },
-            translation: Translation::new(25.0, 75.0, 0.0),
+            sprite: Sprite::new(Vec2::new(1.0, 1.0)),
+            transform: Transform::from_translation(Vec3::new(25.0, 75.0, 0.0)),
             ..Default::default()
         });
-
 }


### PR DESCRIPTION
I would like to try using `bevy_lyon`, but my little project is using Bevy 0.2.1.

This pull request updates `bevy_lyon` to work with Bevy 0.2.1.  (The change isn't nearly as big as it looks, `cargo fmt` felt like changing a lot of stuff)